### PR TITLE
fix same file upload not get removed after distinct process

### DIFF
--- a/fileserver.go
+++ b/fileserver.go
@@ -2255,7 +2255,7 @@ func (this *Server) SaveUploadFile(file multipart.File, header *multipart.FileHe
 	if this.util.FileExists(outPath) && Config().EnableDistinctFile {
 		for i := 0; i < 10000; i++ {
 			outPath = fmt.Sprintf(folder+"/%d_%s", i, filepath.Base(header.Filename))
-			fileInfo.Name = fmt.Sprintf("%d_%s", i, header.Filename)
+			fileInfo.Name = fmt.Sprintf("%d_%s", i, filepath.Base(header.Filename))
 			if !this.util.FileExists(outPath) {
 				break
 			}


### PR DESCRIPTION
修复带路径上传参数时，上传相同的文件，在去重之后，重复文件未被删除