### PR TITLE
paic when file stat error

### DIFF
--- a/fileserver.go
+++ b/fileserver.go
@@ -2327,6 +2327,7 @@ func (this *Server) SaveUploadFile(file multipart.File, header *multipart.FileHe
 	}
 	if fi, err = outFile.Stat(); err != nil {
 		log.Error(err)
+		return fileInfo, errors.New("(error)fail," + err.Error())
 	} else {
 		fileInfo.Size = fi.Size()
 	}


### PR DESCRIPTION
当 outFile.Stat()  出现 错误时， fi会被赋值为nil , 导致后面使用fi.Size()时 引起panic
重现场景： samba mount  + Jmeter 