### PR TITLE
解决adminIP不能使用ip的问题

### DIFF
--- a/fileserver.go
+++ b/fileserver.go
@@ -1876,7 +1876,7 @@ func (this *Server) IsPeer(r *http.Request) bool {
 		return true
 	}
 	for _, v := range Config().AdminIps {
-		if len(strings.Split(v, "/")) > 0 {
+		if strings.Contains(v, "/") {
 			if _, cidr, err = net.ParseCIDR(v); err != nil {
 				log.Error(err)
 				return false


### PR DESCRIPTION
len(strings.Split(v, "/")) > 0    在string 不为空时，恒为true