### PR TITLE
为了方便基于Docker部署增加peers和peerId的环境变量获取。

### DIFF
--- a/fileserver.go
+++ b/fileserver.go
@@ -3803,14 +3803,21 @@ func init() {
 	}
 	server = NewServer()
 
-	peerId := fmt.Sprintf("%d", server.util.RandInt(0, 9))
+	var peerId string
+	if peerId = os.Getenv("GO_FASTDFS_PEER_ID"); peerId == "" {
+		peerId = fmt.Sprintf("%d", server.util.RandInt(0, 9))
+	}
 	if !server.util.FileExists(CONST_CONF_FILE_NAME) {
 		var ip string
 		if ip = os.Getenv("GO_FASTDFS_IP"); ip == "" {
 			ip = server.util.GetPulicIP()
 		}
 		peer := "http://" + ip + ":8080"
-		cfg := fmt.Sprintf(cfgJson, peerId, peer, peer)
+		var peers string
+		if peers = os.Getenv("GO_FASTDFS_PEERS"); peers == ""{
+			peers = peer
+		}
+		cfg := fmt.Sprintf(cfgJson, peerId, peer, peers)
 		server.util.WriteFile(CONST_CONF_FILE_NAME, cfg)
 	}
 	if logger, err := log.LoggerFromConfigAsBytes([]byte(logConfigStr)); err != nil {


### PR DESCRIPTION
修改3806-3822行，增加`GO_FASTDFS_PEER_ID`和`GO_FASTDFS_PEERS`用来传递对应的`peerId`和`peers`对应的参数，方便基于容器和k8s进行集群部署。
```go
        var peerId string
	if peerId = os.Getenv("GO_FASTDFS_PEER_ID"); peerId == "" {
		peerId = fmt.Sprintf("%d", server.util.RandInt(0, 9))
	}
	if !server.util.FileExists(CONST_CONF_FILE_NAME) {
		var ip string
		if ip = os.Getenv("GO_FASTDFS_IP"); ip == "" {
			ip = server.util.GetPulicIP()
		}
		peer := "http://" + ip + ":8080"
		var peers string
		if peers = os.Getenv("GO_FASTDFS_PEERS"); peers == ""{
			peers = peer
		}
		cfg := fmt.Sprintf(cfgJson, peerId, peer, peers)
		server.util.WriteFile(CONST_CONF_FILE_NAME, cfg)
	}
```