### PR TITLE
优化gofastdfs.service

### DIFF
--- a/gofastdfs.service
+++ b/gofastdfs.service
@@ -4,6 +4,7 @@ Wants=network.target
 
 [Service]
 PIDFile=/home/gofastdfs/conf/app.pid
+WorkingDirectory=/home/gofastdfs
 Environment="GO_FASTDFS_DIR=/home/gofastdfs" #/home/gofastdfs 修改成你的安装路径
 ExecStart=/home/gofastdfs/fileserver $GO_FASTDFS_DIR
 ExecReload=/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
添加WorkingDirectory来指定gofastdfs的工作目录, 使gofastdfs.service能成功运行, 避免出现"请切换到  /home/gofastdfs 目录启动 fileserver "的报错