### PR TITLE
bugfix diskInfo status path #298

### DIFF
--- a/server/http_info.go
+++ b/server/http_info.go
@@ -3,7 +3,6 @@ package server
 import (
 	"fmt"
 
-	"path/filepath"
 	"runtime"
 
 	"io/ioutil"
@@ -330,7 +329,6 @@ func (c *Server) Status(w http.ResponseWriter, r *http.Request) {
 		ok       bool
 		v        interface{}
 		err      error
-		appDir   string
 		diskInfo *disk.UsageStat
 		memInfo  *mem.VirtualMemoryStat
 	)
@@ -374,11 +372,7 @@ func (c *Server) Status(w http.ResponseWriter, r *http.Request) {
 	sts["Sys.GCCPUFraction"] = memStat.GCCPUFraction
 	sts["Sys.GCSys"] = memStat.GCSys
 	//sts["Sys.MemInfo"] = memStat
-	appDir, err = filepath.Abs(".")
-	if err != nil {
-		log.Error(err)
-	}
-	diskInfo, err = disk.Usage(appDir)
+	diskInfo, err = disk.Usage(STORE_DIR)
 	if err != nil {
 		log.Error(err)
 	}


### PR DESCRIPTION
此处`appDir`代表程序运行路径，`STORE_DIR`代表数据文件存储路径，原代码中磁盘检查路径为程序运行路径，但一般磁盘空间统计的需求是计算数据文件存储路径，所以建议将`appDir`改为`STORE_DIR`，并且将以上不再被使用的import和变量定义以及程序运行路径获取逻辑代码去掉，以上代码已经完成了业务测试